### PR TITLE
OY-5648: kirjastopäivitykset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.6</version>
+        <version>3.5.14</version>
     </parent>
 
     <dependencyManagement>
@@ -36,14 +36,9 @@
                 <version>0.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-to-slf4j</artifactId>
-                <version>2.17.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>2.17.0</version>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>9.37.4</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/src/main/resources/webapp/app/valintaryhmalistaus/valintaryhmaHakukohdeTree.js
+++ b/src/main/resources/webapp/app/valintaryhmalistaus/valintaryhmaHakukohdeTree.js
@@ -3,11 +3,14 @@ angular
 
   .factory('Treemodel', [
     '$resource',
+    '$timeout',
     'ValintaperusteetPuu',
     'AuthService',
     'HakuModel',
-    function ($resource, ValintaperusteetPuu, AuthService, HakuModel) {
+    function ($resource, $timeout, ValintaperusteetPuu, AuthService, HakuModel) {
       'use strict'
+
+      var refreshHakuTimer = null
 
       //and return interface for manipulating the model
       var modelInterface = {
@@ -71,27 +74,34 @@ angular
           })
         },
         refreshHaku: function (haku) {
-          var kohdejoukko, tila
-
-          if (haku.kohdejoukkoUri) {
-            kohdejoukko = haku.kohdejoukkoUri.split('#')[0]
+          var that = this
+          if (refreshHakuTimer) {
+            $timeout.cancel(refreshHakuTimer)
           }
-          if (this.search.vainValmiitJaJulkaistut) {
-            tila = ['VALMIS', 'JULKAISTU']
-          }
+          refreshHakuTimer = $timeout(function () {
+            refreshHakuTimer = null
+            var kohdejoukko, tila
 
-          ValintaperusteetPuu.get(
-            {
-              q: this.search.q,
-              hakuOid: haku.oid,
-              tila: tila,
-              kohdejoukko: kohdejoukko,
-            },
-            function (result) {
-              modelInterface.valintaperusteList = result
-              modelInterface.update()
+            if (haku.kohdejoukkoUri) {
+              kohdejoukko = haku.kohdejoukkoUri.split('#')[0]
             }
-          )
+            if (that.search.vainValmiitJaJulkaistut) {
+              tila = ['VALMIS', 'JULKAISTU']
+            }
+
+            ValintaperusteetPuu.get(
+              {
+                q: that.search.q,
+                hakuOid: haku.oid,
+                tila: tila,
+                kohdejoukko: kohdejoukko,
+              },
+              function (result) {
+                modelInterface.valintaperusteList = result
+                modelInterface.update()
+              }
+            )
+          }, 300)
         },
         expandTree: function () {
           modelInterface.forEachValintaryhma(function (item) {


### PR DESCRIPTION
OY-5648: kirjastopäivitykset ja puu-rajapinnan debounce

Muutokset

Kirjastopäivitykset (pom.xml)
- Spring Boot 3.5.6 → 3.5.14
- Poistettu log4j-versiopinning (2.17.0): Spring Boot BOM hallitsee version nyt automaattisesti uudemmalla versiolla
- Lisätty nimbus-jose-jwt 9.37.4 korjaamaan CVE-2025-53864 (DoS syvästi sisäkkäisten JWT-objektien kautta, haavoittuvuus tuli transitiivisesti spring-security-cas → cas-client-core -polkua pitkin)

Puu-rajapinnan debounce (valintaryhmaHakukohdeTree.js)
- Lisätty 300 ms debounce refreshHaku-metodiin
- Korjaa käynnistyksen kolminkertaisen puu-kutsun: Treemodel-factory, ValintaryhmaHakukohdeTreeController-watch ja ValintaryhmaPuuValitsinController laukaisivat kukin oman kutsunsa startup-digestin aikana
- Kattaa samalla "Suodata hakukohteita" -kentän: ennen kutsu lähti jokaisen kirjaimen jälkeen